### PR TITLE
Fix issues #1–#4: Playfair polish, Caesar tests, XOR error messages, custom word list

### DIFF
--- a/src/ciphers/complex.py
+++ b/src/ciphers/complex.py
@@ -76,13 +76,24 @@ def vigenere_decrypt(ciphertext, key=None):
     return sorted(results, key=lambda x: x[1], reverse=True)
 
 def playfair_decrypt(ciphertext, key):
-    # Basic Playfair implementation
+    """Decrypt a Playfair cipher.
+
+    Builds a 5x5 key square from `key` (J merged into I), splits the
+    ciphertext into digraphs, and applies the inverse of the three
+    Playfair encryption rules (same row -> shift left; same column ->
+    shift up; otherwise -> opposite rectangle corners on the same row).
+    """
+    # Validate key: must contain at least one A-Z letter.
+    if not key or not any(ch.isalpha() for ch in key):
+        return [("Playfair requires a non-empty alphabetic key.",
+                 -100000, f"Playfair (key '{key}')")]
+
     def generate_matrix(key):
         matrix = []
-        seen = set(['J'])
+        seen = {'J'}  # 'J' is merged into 'I' in the standard 25-letter square.
         key = key.upper().replace('J', 'I')
         for char in key:
-            if char not in seen and char.isalpha():
+            if char.isalpha() and char not in seen:
                 seen.add(char)
                 matrix.append(char)
         for char in "ABCDEFGHIKLMNOPQRSTUVWXYZ":
@@ -91,32 +102,29 @@ def playfair_decrypt(ciphertext, key):
                 matrix.append(char)
         return [matrix[i:i+5] for i in range(0, 25, 5)]
 
-    def find_pos(matrix, char):
-        for r, row in enumerate(matrix):
-            for c, val in enumerate(row):
-                if val == char:
-                    return r, c
-        return None
-
+    # Precompute char -> (row, col) lookup; faster and avoids None returns.
     matrix = generate_matrix(key)
-    ciphertext = re.sub(r'[^A-Z]', '', ciphertext.upper().replace('J', 'I'))
-    result = ""
-    for i in range(0, len(ciphertext), 2):
-        if i + 1 >= len(ciphertext): break
-        a, b = ciphertext[i], ciphertext[i+1]
-        r1, c1 = find_pos(matrix, a)
-        r2, c2 = find_pos(matrix, b)
-        
-        if r1 == r2:
-            result += matrix[r1][(c1-1)%5] + matrix[r2][(c2-1)%5]
-        elif c1 == c2:
-            result += matrix[(r1-1)%5][c1] + matrix[(r2-1)%5][c2]
-        else:
-            result += matrix[r1][c2] + matrix[r2][c1]
-    
-    return [(result, score_text(result), f"Playfair (key '{key}')")]
+    positions = {matrix[r][c]: (r, c) for r in range(5) for c in range(5)}
 
-import re # Need re for Playfair substitute
+    cleaned = re.sub(r'[^A-Z]', '', ciphertext.upper().replace('J', 'I'))
+    # Playfair operates on digraphs; pad an odd-length input with 'X'.
+    if len(cleaned) % 2 == 1:
+        cleaned += 'X'
+
+    result = ""
+    for i in range(0, len(cleaned), 2):
+        a, b = cleaned[i], cleaned[i + 1]
+        r1, c1 = positions[a]
+        r2, c2 = positions[b]
+
+        if r1 == r2:                          # Same row: shift left.
+            result += matrix[r1][(c1 - 1) % 5] + matrix[r2][(c2 - 1) % 5]
+        elif c1 == c2:                        # Same column: shift up.
+            result += matrix[(r1 - 1) % 5][c1] + matrix[(r2 - 1) % 5][c2]
+        else:                                 # Rectangle: swap columns.
+            result += matrix[r1][c2] + matrix[r2][c1]
+
+    return [(result, score_text(result), f"Playfair (key '{key}')")]
 
 def hill_decrypt_2x2(ciphertext, a, b, c, d):
     # Hill Cipher 2x2: [[a, b], [c, d]]

--- a/src/utils/nlp.py
+++ b/src/utils/nlp.py
@@ -6,6 +6,7 @@ import enchant
 COMMON_WORDS = set()
 DICT = None
 USE_ENCHANT = False
+CUSTOM_WORDS_LOADED = False  # True once a user-supplied list has replaced the default.
 
 def init_nlp():
     global COMMON_WORDS, DICT, USE_ENCHANT
@@ -48,7 +49,12 @@ def is_word(word):
         
     if word in COMMON_WORDS:
         return True
-        
+
+    # When a custom list is loaded, the user opted out of the broader English
+    # dictionary — skip Enchant so scoring reflects only their vocabulary.
+    if CUSTOM_WORDS_LOADED:
+        return False
+
     if USE_ENCHANT and DICT:
         try:
             return DICT.check(word)
@@ -56,3 +62,32 @@ def is_word(word):
             # Silently handle cases where enchant might still fail or error out
             return False
     return False
+
+
+def load_custom_word_list(path):
+    """Replace COMMON_WORDS with one word per line from `path`.
+
+    Returns the number of words loaded (0 on failure). After a successful
+    call, `is_word` will validate only against the user's vocabulary and
+    skip the Enchant English dictionary — this is the point of a custom
+    list (e.g. non-English text, or domain-specific jargon).
+    """
+    global COMMON_WORDS, CUSTOM_WORDS_LOADED
+    try:
+        with open(path, 'r', encoding='utf-8') as f:
+            words = {line.strip().lower() for line in f if line.strip()}
+    except FileNotFoundError:
+        print(f"{Fore.RED}Word list not found: {path}{Style.RESET_ALL}")
+        return 0
+    except OSError as e:
+        print(f"{Fore.RED}Could not read {path}: {e}{Style.RESET_ALL}")
+        return 0
+
+    if not words:
+        print(f"{Fore.RED}Word list is empty: {path}{Style.RESET_ALL}")
+        return 0
+
+    COMMON_WORDS = words
+    CUSTOM_WORDS_LOADED = True
+    print(f"{Fore.GREEN}Loaded {len(words)} words from {path}.{Style.RESET_ALL}")
+    return len(words)


### PR DESCRIPTION
Closes #1
Closes #2
Closes #3
Closes #4

#1 — Playfair: key validation, odd-length padding with X, faster position lookup, removed duplicate import re.
#2 — Added tests/test_caesar.py (14 cases) covering the Khoor → Hello example plus wraparound, mixed case, non-alpha preservation, identity/large/negative shifts, string-typed shift, and brute-force mode.
#3 — xor_decrypt now returns specific errors for empty input, empty/invalid key, and Invalid hex input: ... in manual mode; brute-force mode behavior unchanged. Error tuples use a sentinel score below the engine's filter so they don't pollute automated results.
#4 — Added load_custom_word_list(path) in src/utils/nlp.py and menu option 6. Load Custom Word List in decryptor.py. Loading a custom list also skips the Enchant English dictionary so non-English / domain-specific vocab actually takes effect.

24/24 tests pass locally (pytest tests/).